### PR TITLE
Use nonUniqueSlug for GDPR compliance pages

### DIFF
--- a/pages/is-gdpr-compliant/[slug].vue
+++ b/pages/is-gdpr-compliant/[slug].vue
@@ -1,7 +1,7 @@
 <template>
   <Article
     name="is-gdpr-compliant-slug"
-    :slug="route.params.slug"
+    :nonUniqueSlug="route.params.slug"
     articleType="gdpr-compliance"
     :keys="['reviews']"
   />

--- a/pages/is-gdpr-compliant/index.vue
+++ b/pages/is-gdpr-compliant/index.vue
@@ -19,7 +19,7 @@
           :to="
             localePath({
               name: 'is-gdpr-compliant-slug',
-              params: { slug: article.slug },
+              params: { slug: article.nonUniqueSlug },
             })
           "
           class="block"
@@ -43,6 +43,7 @@ const {
 } = await useArticle({
   routeName: "is-gdpr-compliant-slug",
   articleType: "gdpr-compliance",
+  keys: ["nonUniqueSlug"],
 });
 
 const articles = computed(() => articlesData.value?.articles || []);


### PR DESCRIPTION
## Summary
- link to GDPR-compliance articles using `nonUniqueSlug`
- load article content in slug page with `nonUniqueSlug`

## Testing
- `npm run prettier`
- `npm run test` *(fails: Cannot find module '/workspace/marketing-site/.output/server/index.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_683f34dc0cb08323a07faf37fb18a5bc