### PR TITLE
Add Netlify and AI signup option

### DIFF
--- a/components/SignupStep2.vue
+++ b/components/SignupStep2.vue
@@ -29,9 +29,13 @@
           <option value="hackernews">Hacker News</option>
           <option value="x">X / Twitter</option>
           <option value="linkedin">LinkedIn</option>
+          <option value="netlify">Netlify</option>
           <option value="blog">Blog</option>
           <option value="podcast">Podcast</option>
           <option value="youtube">Youtube</option>
+          <option value="ai">
+            ChatGPT / Perplexity / Gemini / Claude / Others
+          </option>
           <option value="other">Other</option>
         </select>
         <div v-if="signupSourceErrors.length" class="mt-1">


### PR DESCRIPTION
## Summary
- extend signup sources with a combined AI option

## Testing
- `npm run prettier`
- `npm run test` *(fails: Cannot find module '.output/server/index.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_6852b34f29ec83239ba61772673f73cd